### PR TITLE
Prevent inclusion of multiple versions of jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ The most minimal usage would be to create a `karma.conf.js` file in the root of 
 module.exports = require('karma-config-rentpath')
 ```
 
+And then set up an entry file to load the tests at path `/spec/javascripts/tests.bundle.js`:
+```javascript
+var context = require.context('.', true, /.+_spec\.(coffee|js|jsx)$/);
+context.keys().forEach(context);
+module.exports = context;
+```
+
+If your app requires [jasmine-jquery](https://github.com/velesin/jasmine-jquery) or [jasmine-flight](https://github.com/flightjs/jasmine-flight) you will need to import them at the top of the entry file:
+```javascript
+require('jasmine-jquery')
+require('webpack-jasmine-flight')
+```
+
 If your app has special needs, you'll want to apply the shared configuration then any custom configuration. For example:
 
 ```javascript

--- a/src/index.js
+++ b/src/index.js
@@ -33,18 +33,6 @@ export default function(config) {
     ],
     files: [
       {
-        pattern: 'node_modules/jasmine-jquery/lib/jasmine-jquery.js',
-        watched: false,
-        served: true,
-        included: true
-      },
-      {
-        pattern: 'node_modules/webpack-jasmine-flight/lib/jasmine-flight.js',
-        watched: false,
-        served: true,
-        included: true
-      },
-      {
         pattern: 'spec/javascripts/fixtures/**',
         watched: true,
         served: true,


### PR DESCRIPTION
Including `jasmine-jquery` and `jasmine-flight` in the previous manner caused each lib to be loaded (by phantomjs) as a separate bundle, each with its own copy of `jquery`.  If the application also uses `jquery` (assumed) then the test bundle would also receive its own instance of `jquery`, which makes event testing difficult, if not impossible.

This change removes the automatic inclusion of both libs, and requires the consuming application to require them both explicitly, thereby ensuring the tests and each lib share the same `jquery` instance.